### PR TITLE
Updated Readme with requires PHP v5.4.7+

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Laravel Markdown was created by, and is maintained by [Graham Campbell](https://
 
 ## Installation
 
-[PHP](https://php.net) 5.4+ or [HHVM](http://hhvm.com) 3.2+, and [Composer](https://getcomposer.org) are required.
+[PHP](https://php.net) 5.4.7+ or [HHVM](http://hhvm.com) 3.2+, and [Composer](https://getcomposer.org) are required.
 
 To get the latest version of Laravel Markdown, simply require `"graham-campbell/markdown": "~2.0"` in your `composer.json` file. You'll then need to run `composer install` or `composer update` to download it and have the autoloader updated.
 


### PR DESCRIPTION
This is important because, Debian 7 "Wheezy" currently only ships with v5.4.4 and therefore a work around is needed to use this package.
