### PR TITLE
Markdown extensions

### DIFF
--- a/config/markdown.php
+++ b/config/markdown.php
@@ -27,4 +27,21 @@ return [
 
     'views' => true,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Enable Markdown Extensions
+    |--------------------------------------------------------------------------
+    |
+    | This option specifies the extensions class to register with the markdown
+    | environment.  You may register any extensions that uses the environment's
+    | addExtension method.
+    |
+    | Default: []
+    |
+    */
+
+    'extensions' => [
+        //
+    ],
+
 ];

--- a/src/MarkdownServiceProvider.php
+++ b/src/MarkdownServiceProvider.php
@@ -155,6 +155,11 @@ class MarkdownServiceProvider extends ServiceProvider
     {
         $app->singleton('markdown', function ($app) {
             $environment = $app['markdown.environment'];
+
+            if ($this->app->config->get('markdown.extensions')) {
+                $this->registerMarkdownExtensions($app);
+            }
+
             $docParser = new DocParser($environment);
             $htmlRenderer = new HtmlRenderer($environment);
 
@@ -162,6 +167,24 @@ class MarkdownServiceProvider extends ServiceProvider
         });
 
         $app->alias('markdown', Converter::class);
+    }
+
+    /**
+     * Register the markdowm extensions class.
+     *
+     * @param \Illuminate\Contracts\Foundation\Application $app
+     *
+     * @return void
+     */
+    protected function registerMarkdownExtensions(Application $app)
+    {
+        $environment = $app['markdown.environment'];
+
+        foreach($this->app->config->get('markdown.extensions') as $extension) {
+            if (class_exists($extension)) {
+                $environment->addExtension(new $extension);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Add the possibility of registering extensions via the commonmark environment's addExtension method.

Here's a few extension available:
- [CommonMark Attributes Extension](https://github.com/webuni/commonmark-attributes-extension)
- [CommonMark Table Extension](https://github.com/webuni/commonmark-table-extension)

