### PR TITLE
change installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ You'll then need to run `composer install` or `composer update` to download it a
 
 Once Laravel Markdown is installed, you need to register the service provider. Open up `config/app.php` and add the following to the `providers` key.
 
-* `'GrahamCampbell\Markdown\MarkdownServiceProvider'`
+* `GrahamCampbell\Markdown\MarkdownServiceProvider::class`
 
 You can register the Markdown facade in the `aliases` key of your `config/app.php` file if you like.
 
-* `'Markdown' => 'GrahamCampbell\Markdown\Facades\Markdown'`
+* `'Markdown' => GrahamCampbell\Markdown\Facades\Markdown::class`
 
 
 ## Configuration
@@ -42,7 +42,7 @@ Laravel Markdown supports optional configuration.
 To get started, you'll need to publish all vendor assets:
 
 ```bash
-$ php artisan vendor:publish
+$ php artisan vendor:publish --provider="GrahamCampbell\Markdown\MarkdownServiceProvider"
 ```
 
 This will create a `config/markdown.php` file in your app that you can modify to set your configuration. Also, make sure you check for changes to the original config file in this package between releases.


### PR DESCRIPTION
change installation instructions to Laravel 5 format for providers, using class instead of string, and add provider to artisan publish command so that you don't wind up publishing what every installed vendor has available.

Some available tags are optional in packages. These updated instructions prevent the user accidentally publishing what they did not want from other vendors.