### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This option (`'use_underscore'`) specifies if `_` should be parsed for emphasis.
 
 ##### Safe Mode
 
-This option (`'safe'`) specifies if raw HTML is rendered in the document. Setting this to `true` will not render HTML, and `false` will not. The default value for this setting is `false`.
+This option (`'safe'`) specifies if raw HTML is rendered in the document. Setting this to `true` will not render HTML, and `false` will. The default value for this setting is `false`.
 
 
 ## Usage


### PR DESCRIPTION
Both the true and false states of `safe` were described as _not_ rendering HTML.  I hope I got the documentation the correct way around.