### PR TITLE
Add publish config file with tag

### DIFF
--- a/src/MarkdownServiceProvider.php
+++ b/src/MarkdownServiceProvider.php
@@ -45,6 +45,10 @@ class MarkdownServiceProvider extends ServiceProvider
             $this->enablePhpMarkdownEngine();
             $this->enableBladeMarkdownEngine();
         }
+
+        $this->publishes([
+            realpath(__DIR__.'/../config/markdown.php') => config_path('markdown.php')
+        ], 'markdown');
     }
 
     /**

--- a/src/MarkdownServiceProvider.php
+++ b/src/MarkdownServiceProvider.php
@@ -47,7 +47,7 @@ class MarkdownServiceProvider extends ServiceProvider
         }
 
         $this->publishes([
-            realpath(__DIR__.'/../config/markdown.php') => config_path('markdown.php')
+            realpath(__DIR__.'/../config/markdown.php') => config_path('markdown.php'),
         ], 'markdown');
     }
 


### PR DESCRIPTION
Hi,

Thanks for the package!

I found out that your service provider was missing the option to publish only its config file without having to publish all service providers publishable files.

This pull request fixes this small issue.

Here's how to use it with artisan:
`php artisan vendor:publish --tag=markdown`

Could you please merge this commit?
