### PR TITLE
Add a markdown Blade directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ There are several config options:
 
 ##### Enable View Integration
 
-This option (`'views'`) specifies if the view integration is enabled so you can write markdown views and have them rendered as html. The following extensions are currently supported: `'.md'`, `'.md.php'`, and `'.md.blade.php'`. You may disable this integration if it is conflicting with another package. The default value for this setting is `true`.
+This option (`'views'`) specifies if the view integration is enabled so you can write markdown views and have them rendered as html. The following extensions are currently supported: `'.md'`, `'.md.php'`, and `'.md.blade.php'`. Additionally, this will enable the `@markdown` Blade directive. You may disable this integration if it is conflicting with another package. The default value for this setting is `true`.
 
 ##### CommonMark Extensions
 
@@ -129,7 +129,36 @@ class Foo
 App::make('Foo')->bar();
 ```
 
-And don't forget, that's just the basics. We also support extension through listening for the resolving event from the container, and we ship with integration with Laravel's view system.
+And don't forget, that's just the basics. We also support extension through listening for the resolving event from the container, and we ship with integration with Laravel's view system. You can use both the `@markdown` blade directive, and also using the following file extensions will compile your views as markdown: `'.md'`, `'.md.php'`, and `'.md.blade.php'`.
+
+For example, the following are all methods of rendering markdown:
+
+*`foo.blade.php`*:
+```blade
+@markdown('# Foo')
+```
+
+*`bar.blade.php`*:
+```blade
+@markdown
+# Bar
+@endmarkdown
+```
+
+*`baz1.md`*:
+```
+# Baz 1
+```
+
+*`baz2.md.php`*:
+```
+# Baz 2
+```
+
+*`baz3.md.blade.php`*:
+```
+# Baz 3
+```
 
 ##### Further Information
 

--- a/src/MarkdownServiceProvider.php
+++ b/src/MarkdownServiceProvider.php
@@ -47,6 +47,8 @@ class MarkdownServiceProvider extends ServiceProvider
             $this->enablePhpMarkdownEngine();
             $this->enableBladeMarkdownEngine();
         }
+
+        $this->enableBladeDirective();
     }
 
     /**
@@ -120,6 +122,23 @@ class MarkdownServiceProvider extends ServiceProvider
         });
 
         $app->view->addExtension('md.blade.php', 'blademd');
+    }
+
+    protected function enableBladeDirective()
+    {
+        $app = $this->app;
+
+        $app['blade.compiler']->directive('markdown', function($markdown) {
+            if ($markdown) {
+                return "<?php echo app('markdown')->convertToHtml({$markdown}); ?>";
+            }
+
+            return '<?php ob_start(); ?>';
+        });
+
+        $app['blade.compiler']->directive('endmarkdown', function () {
+            return "<?php echo app('markdown')->convertToHtml(ob_get_clean()); ?>";
+        });
     }
 
     /**

--- a/src/MarkdownServiceProvider.php
+++ b/src/MarkdownServiceProvider.php
@@ -129,7 +129,7 @@ class MarkdownServiceProvider extends ServiceProvider
 
         $app['blade.compiler']->directive('markdown', function($markdown) {
             if ($markdown) {
-                return "<?php echo app('markdown')->convertToHtml({$markdown}); ?>";
+                return "<?php echo app('markdown')->convertToHtml((string) {$markdown}); ?>";
             }
 
             return '<?php ob_start(); ?>';

--- a/src/MarkdownServiceProvider.php
+++ b/src/MarkdownServiceProvider.php
@@ -46,9 +46,8 @@ class MarkdownServiceProvider extends ServiceProvider
             $this->enableMarkdownCompiler();
             $this->enablePhpMarkdownEngine();
             $this->enableBladeMarkdownEngine();
+            $this->enableBladeDirective();
         }
-
-        $this->enableBladeDirective();
     }
 
     /**

--- a/src/MarkdownServiceProvider.php
+++ b/src/MarkdownServiceProvider.php
@@ -127,7 +127,7 @@ class MarkdownServiceProvider extends ServiceProvider
     {
         $app = $this->app;
 
-        $app['blade.compiler']->directive('markdown', function($markdown) {
+        $app['blade.compiler']->directive('markdown', function ($markdown) {
             if ($markdown) {
                 return "<?php echo app('markdown')->convertToHtml((string) {$markdown}); ?>";
             }

--- a/tests/Functional/MarkdownViewTest.php
+++ b/tests/Functional/MarkdownViewTest.php
@@ -56,4 +56,18 @@ class MarkdownViewTest extends AbstractTestCase
 
         $this->assertSame("<h1>Bar</h1>\n", $return);
     }
+
+    public function testBladeDirectiveInline()
+    {
+        $return = $this->app->view->make('stubs::baz')->render();
+
+        $this->assertSame("<h1>Baz</h1>\n", $return);
+    }
+
+    public function testBladeDirectiveBlock()
+    {
+        $return = $this->app->view->make('stubs::qux')->render();
+
+        $this->assertSame("<h1>Qux</h1>\n", $return);
+    }
 }

--- a/tests/Functional/stubs/baz.blade.php
+++ b/tests/Functional/stubs/baz.blade.php
@@ -1,0 +1,1 @@
+@markdown('# Baz')

--- a/tests/Functional/stubs/qux.blade.php
+++ b/tests/Functional/stubs/qux.blade.php
@@ -1,0 +1,3 @@
+@markdown
+# Qux
+@endmarkdown


### PR DESCRIPTION
This is useful for rendering Markdown content that isn't stored in a template, such as blog post contents, or other partial content which should be parsed as Markdown without affecting the entire view.