### PR TITLE
Update league/commonmark to 0.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,33 @@ There are other classes in this package that are not documented here (such as th
 
 As hinted in the configuration docs, CommonMark can be modified using extensions. There are some very good examples in the customization section of the CommonMark docs for how to create custom parsers and renders in the customization section: http://commonmark.thephpleague.com/.
 
-Alt Three's Emoji package also serves as a good example of how to implement the full deal: https://github.com/AltThree/Emoji. In particular, note the presence of the [Extension class](https://github.com/AltThree/Emoji/blob/master/src/EmojiExtension.php), and the fact that you can add it to the extensions array in your `app/config/markdown.php` file. If you don't see the file in your config folder, you would need to run `php artisan vendor:publish`.
+CommonMark Strikethrough package also serves as a good example of how to implement the full deal: https://github.com/thephpleague/commonmark-ext-strikethrough.
+In particular, note the presence of the [Extension class](https://github.com/thephpleague/commonmark-ext-strikethrough/blob/master/src/StrikethroughExtension.php). 
+
+To activate the extension add it to the extensions array in your `app/config/markdown.php` file. If you don't see the file in your config folder, you would need to run `php artisan vendor:publish`.
+
+#### Upgrading from 10.3
+
+[CommonMark 0.19](http://commonmark.thephpleague.com/) change how extensions are defined.
+Now the `ExtensionInterface` define a single method, `register`, in which you will receive an instance of the environment.
+
+```php
+
+use League\CommonMark\Extension\ExtensionInterface;
+use League\CommonMark\ConfigurableEnvironmentInterface;
+
+final class EmojiExtension implements ExtensionInterface
+{
+    public function register(ConfigurableEnvironmentInterface $environment)
+    {
+        $environment
+            ->addInlineParser(new EmojiParser(), 20)
+            ->addDocumentProcessor(new ReplaceUnicodeEmojiProcessor(), 0)
+            ->addInlineRenderer(Emoji::class, new EmojiRenderer(), 0)
+        ;
+    }
+}
+```
 
 
 ## Security

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
         "illuminate/contracts": "5.5.*|5.6.*|5.7.*|5.8.*",
         "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*",
         "illuminate/view": "5.5.*|5.6.*|5.7.*|5.8.*",
-        "league/commonmark": "^0.18"
+        "league/commonmark": "^0.19"
     },
     "require-dev": {
         "graham-campbell/analyzer": "^2.1",
         "graham-campbell/testbench": "^5.2",
-        "league/commonmark-extras": "^0.1.5",
+        "league/commonmark-extras": "^0.3.0",
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^6.5|^7.0|^8.0"
     },

--- a/tests/Facades/MarkdownTest.php
+++ b/tests/Facades/MarkdownTest.php
@@ -17,7 +17,7 @@ use GrahamCampbell\Markdown\Facades\Markdown;
 use GrahamCampbell\TestBenchCore\FacadeTrait;
 use GrahamCampbell\Tests\Markdown\AbstractTestCase;
 use League\CommonMark\Converter;
-use League\CommonMark\Extras\SmartPunct\SmartPunctExtension;
+use League\CommonMark\Ext\SmartPunct\SmartPunctExtension;
 
 /**
  * This is the markdown facade test class.


### PR DESCRIPTION
Hi, thanks for the package. I saw that you require `league/commonmark` `0.18`, but checking the documentation there is a new version available: 0.19. This version is particularly interesting as define an improved way to add extensions.

So I opened this pull request to change the `league/commonmark` requirement to `^0.19` and update the `league/commonmark-extras` to the latest version to ensure adding extensions continue to work as expected.

I also updated the "Extension" section in the readme because `league/commonmark` 0.19 introduce what I think is a breaking change.