### PR TITLE
Run unit tests with 'composer test'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,9 @@
             ]
         }
     },
+    "scripts": {
+        "test": "phpunit"
+    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }


### PR DESCRIPTION
Composer allows you to define a special script named `test` which can be executed by running `composer test`.  By adopting this pattern, anyone can easily run the test suite using a standard command without needing to know which test framework is being used.