### PR TITLE
CommonMark 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
         "illuminate/contracts": "5.5.*|5.6.*|5.7.*|5.8.*",
         "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*",
         "illuminate/view": "5.5.*|5.6.*|5.7.*|5.8.*",
-        "league/commonmark": "^0.18"
+        "league/commonmark": "^1.0"
     },
     "require-dev": {
         "graham-campbell/analyzer": "^2.1",
         "graham-campbell/testbench": "^5.2",
-        "league/commonmark-extras": "^0.1.5",
+        "league/commonmark-extras": "^1.0",
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^6.5|^7.0|^8.0"
     },

--- a/tests/Facades/MarkdownTest.php
+++ b/tests/Facades/MarkdownTest.php
@@ -17,7 +17,7 @@ use GrahamCampbell\Markdown\Facades\Markdown;
 use GrahamCampbell\TestBenchCore\FacadeTrait;
 use GrahamCampbell\Tests\Markdown\AbstractTestCase;
 use League\CommonMark\Converter;
-use League\CommonMark\Extras\SmartPunct\SmartPunctExtension;
+use League\CommonMark\Ext\SmartPunct\SmartPunctExtension;
 
 /**
  * This is the markdown facade test class.
@@ -65,9 +65,9 @@ class MarkdownTest extends AbstractTestCase
         $this->assertSame("<p>foo</p>\n", $result);
     }
 
-    public function testSafeConversion()
+    public function testDisallowingUnsafeLinks()
     {
-        $this->app->config->set('markdown.safe', true);
+        $this->app->config->set('markdown.allow_unsafe_links', false);
 
         $result = Markdown::convertToHtml("[Click me](javascript:alert('XSS'))");
 


### PR DESCRIPTION
This PR provides support for `league/commonmark` 1.0! (#127)

Based on a cursory look of the `src` directory, I don't see any code changes that need to be made.  However, I did have to adjust the tests for two reasons:

 - The `SmartPunctExtension` was moved into a new library with a new namespace
 - The previously-deprecated `safe` option was removed (see https://github.com/thephpleague/commonmark/blob/master/CHANGELOG-0.x.md#0140---2016-07-02)