### PR TITLE
Update deprecated classes Converter and ConverterInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ This option (`'max_nesting_level'`) specifies the maximum permitted block nestin
 
 ##### Facades\Markdown
 
-This facade will dynamically pass static method calls to the `'markdown'` object in the ioc container which by default is an instance of `League\CommonMark\ConverterInterface`.
+This facade will dynamically pass static method calls to the `'markdown'` object in the ioc container which by default is an instance of `League\CommonMark\MarkdownConverterInterface`.
 
 ##### MarkdownServiceProvider
 
@@ -124,13 +124,13 @@ If you prefer to use dependency injection over facades like me, then you can eas
 
 ```php
 use Illuminate\Support\Facades\App;
-use League\CommonMark\ConverterInterface;
+use League\CommonMark\MarkdownConverterInterface;
 
 class Foo
 {
     protected $converter;
 
-    public function __construct(ConverterInterface $converter)
+    public function __construct(MarkdownConverterInterface $converter)
     {
         $this->converter = $converter;
     }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "illuminate/contracts": "^6.0|^7.0",
         "illuminate/support": "^6.0|^7.0",
         "illuminate/view": "^6.0|^7.0",
-        "league/commonmark": "^1.3"
+        "league/commonmark": "^1.5"
     },
     "require-dev": {
         "graham-campbell/analyzer": "^3.0",

--- a/src/MarkdownServiceProvider.php
+++ b/src/MarkdownServiceProvider.php
@@ -24,8 +24,8 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Engines\CompilerEngine;
 use Laravel\Lumen\Application as LumenApplication;
 use League\CommonMark\CommonMarkConverter;
-use League\CommonMark\MarkdownConverterInterface;
 use League\CommonMark\Environment;
+use League\CommonMark\MarkdownConverterInterface;
 
 /**
  * This is the markdown service provider class.
@@ -187,6 +187,7 @@ class MarkdownServiceProvider extends ServiceProvider
     {
         $this->app->singleton('markdown', function (Container $app) {
             $environment = $app['markdown.environment'];
+
             return new CommonMarkConverter([], $environment);
         });
 

--- a/src/MarkdownServiceProvider.php
+++ b/src/MarkdownServiceProvider.php
@@ -23,11 +23,9 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Engines\CompilerEngine;
 use Laravel\Lumen\Application as LumenApplication;
-use League\CommonMark\Converter;
-use League\CommonMark\ConverterInterface;
-use League\CommonMark\DocParser;
+use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\MarkdownConverterInterface;
 use League\CommonMark\Environment;
-use League\CommonMark\HtmlRenderer;
 
 /**
  * This is the markdown service provider class.
@@ -189,14 +187,11 @@ class MarkdownServiceProvider extends ServiceProvider
     {
         $this->app->singleton('markdown', function (Container $app) {
             $environment = $app['markdown.environment'];
-            $docParser = new DocParser($environment);
-            $htmlRenderer = new HtmlRenderer($environment);
-
-            return new Converter($docParser, $htmlRenderer);
+            return new CommonMarkConverter([], $environment);
         });
 
-        $this->app->alias('markdown', Converter::class);
-        $this->app->alias('markdown', ConverterInterface::class);
+        $this->app->alias('markdown', CommonMarkConverter::class);
+        $this->app->alias('markdown', MarkdownConverterInterface::class);
     }
 
     /**

--- a/src/View/Compiler/MarkdownCompiler.php
+++ b/src/View/Compiler/MarkdownCompiler.php
@@ -36,8 +36,8 @@ final class MarkdownCompiler extends Compiler implements CompilerInterface
      * Create a new instance.
      *
      * @param \League\CommonMark\CommonMarkConverter $markdown
-     * @param \Illuminate\Filesystem\Filesystem $files
-     * @param string                            $cachePath
+     * @param \Illuminate\Filesystem\Filesystem      $files
+     * @param string                                 $cachePath
      *
      * @return void
      */

--- a/src/View/Compiler/MarkdownCompiler.php
+++ b/src/View/Compiler/MarkdownCompiler.php
@@ -16,7 +16,7 @@ namespace GrahamCampbell\Markdown\View\Compiler;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\View\Compilers\Compiler;
 use Illuminate\View\Compilers\CompilerInterface;
-use League\CommonMark\Converter;
+use League\CommonMark\CommonMarkConverter;
 
 /**
  * This is the markdown compiler class.
@@ -28,20 +28,20 @@ final class MarkdownCompiler extends Compiler implements CompilerInterface
     /**
      * The markdown instance.
      *
-     * @var \League\CommonMark\Converter
+     * @var \League\CommonMark\CommonMarkConverter
      */
     private $markdown;
 
     /**
      * Create a new instance.
      *
-     * @param \League\CommonMark\Converter      $markdown
+     * @param \League\CommonMark\CommonMarkConverter $markdown
      * @param \Illuminate\Filesystem\Filesystem $files
      * @param string                            $cachePath
      *
      * @return void
      */
-    public function __construct(Converter $markdown, Filesystem $files, string $cachePath)
+    public function __construct(CommonMarkConverter $markdown, Filesystem $files, string $cachePath)
     {
         parent::__construct($files, $cachePath);
 
@@ -75,7 +75,7 @@ final class MarkdownCompiler extends Compiler implements CompilerInterface
     /**
      * Return the markdown instance.
      *
-     * @return \League\CommonMark\Converter
+     * @return \League\CommonMark\CommonMarkConverter
      */
     public function getMarkdown()
     {

--- a/src/View/Directive/MarkdownDirective.php
+++ b/src/View/Directive/MarkdownDirective.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace GrahamCampbell\Markdown\View\Directive;
 
-use League\CommonMark\Converter;
+use League\CommonMark\CommonMarkConverter;
 
 /**
  * This is the markdown directive class.
@@ -25,18 +25,18 @@ final class MarkdownDirective
     /**
      * The markdown instance.
      *
-     * @var \League\CommonMark\Converter
+     * @var \League\CommonMark\CommonMarkConverter
      */
     private $markdown;
 
     /**
      * Create a new markdown directive instance.
      *
-     * @param \League\CommonMark\Converter $markdown
+     * @param \League\CommonMark\CommonMarkConverter $markdown
      *
      * @return void
      */
-    public function __construct(Converter $markdown)
+    public function __construct(CommonMarkConverter $markdown)
     {
         $this->markdown = $markdown;
     }

--- a/src/View/Engine/BladeMarkdownEngine.php
+++ b/src/View/Engine/BladeMarkdownEngine.php
@@ -35,7 +35,7 @@ final class BladeMarkdownEngine extends CompilerEngine
      * Create a new instance.
      *
      * @param \Illuminate\View\Compilers\CompilerInterface $compiler
-     * @param \League\CommonMark\CommonMarkConverter $markdown
+     * @param \League\CommonMark\CommonMarkConverter       $markdown
      *
      * @return void
      */

--- a/src/View/Engine/BladeMarkdownEngine.php
+++ b/src/View/Engine/BladeMarkdownEngine.php
@@ -15,7 +15,7 @@ namespace GrahamCampbell\Markdown\View\Engine;
 
 use Illuminate\View\Compilers\CompilerInterface;
 use Illuminate\View\Engines\CompilerEngine;
-use League\CommonMark\Converter;
+use League\CommonMark\CommonMarkConverter;
 
 /**
  * This is the php markdown engine class.
@@ -27,7 +27,7 @@ final class BladeMarkdownEngine extends CompilerEngine
     /**
      * The markdown instance.
      *
-     * @var \League\CommonMark\Converter
+     * @var \League\CommonMark\CommonMarkConverter
      */
     private $markdown;
 
@@ -35,11 +35,11 @@ final class BladeMarkdownEngine extends CompilerEngine
      * Create a new instance.
      *
      * @param \Illuminate\View\Compilers\CompilerInterface $compiler
-     * @param \League\CommonMark\Converter                 $markdown
+     * @param \League\CommonMark\CommonMarkConverter $markdown
      *
      * @return void
      */
-    public function __construct(CompilerInterface $compiler, Converter $markdown)
+    public function __construct(CompilerInterface $compiler, CommonMarkConverter $markdown)
     {
         parent::__construct($compiler);
 
@@ -64,7 +64,7 @@ final class BladeMarkdownEngine extends CompilerEngine
     /**
      * Return the markdown instance.
      *
-     * @return \League\CommonMark\Converter
+     * @return \League\CommonMark\CommonMarkConverter
      */
     public function getMarkdown()
     {

--- a/src/View/Engine/PhpMarkdownEngine.php
+++ b/src/View/Engine/PhpMarkdownEngine.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace GrahamCampbell\Markdown\View\Engine;
 
 use Illuminate\View\Engines\PhpEngine;
-use League\CommonMark\Converter;
+use League\CommonMark\CommonMarkConverter;
 
 /**
  * This is the php markdown engine class.
@@ -26,18 +26,18 @@ final class PhpMarkdownEngine extends PhpEngine
     /**
      * The markdown instance.
      *
-     * @var \League\CommonMark\Converter
+     * @var \League\CommonMark\CommonMarkConverter
      */
     private $markdown;
 
     /**
      * Create a new instance.
      *
-     * @param \League\CommonMark\Converter $markdown
+     * @param \League\CommonMark\CommonMarkConverter $markdown
      *
      * @return void
      */
-    public function __construct(Converter $markdown)
+    public function __construct(CommonMarkConverter $markdown)
     {
         $this->markdown = $markdown;
     }
@@ -60,7 +60,7 @@ final class PhpMarkdownEngine extends PhpEngine
     /**
      * Return the markdown instance.
      *
-     * @return \League\CommonMark\Converter
+     * @return \League\CommonMark\CommonMarkConverter
      */
     public function getMarkdown()
     {

--- a/tests/Facades/MarkdownTest.php
+++ b/tests/Facades/MarkdownTest.php
@@ -16,7 +16,7 @@ namespace GrahamCampbell\Tests\Markdown\Facades;
 use GrahamCampbell\Markdown\Facades\Markdown;
 use GrahamCampbell\TestBenchCore\FacadeTrait;
 use GrahamCampbell\Tests\Markdown\AbstractTestCase;
-use League\CommonMark\Converter;
+use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Extension\SmartPunct\SmartPunctExtension;
 
 /**
@@ -55,7 +55,7 @@ class MarkdownTest extends AbstractTestCase
      */
     protected function getFacadeRoot()
     {
-        return Converter::class;
+        return CommonMarkConverter::class;
     }
 
     public function testConvertToHtml()

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -16,9 +16,9 @@ namespace GrahamCampbell\Tests\Markdown;
 use GrahamCampbell\Markdown\View\Compiler\MarkdownCompiler;
 use GrahamCampbell\Markdown\View\Directive\MarkdownDirective;
 use GrahamCampbell\TestBenchCore\ServiceProviderTrait;
-use League\CommonMark\Converter;
-use League\CommonMark\ConverterInterface;
+use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment;
+use League\CommonMark\MarkdownConverterInterface;
 
 /**
  * This is the service provider test class.
@@ -36,8 +36,8 @@ class ServiceProviderTest extends AbstractTestCase
 
     public function testMarkdownIsInjectable()
     {
-        $this->assertIsInjectable(Converter::class);
-        $this->assertIsInjectable(ConverterInterface::class);
+        $this->assertIsInjectable(CommonMarkConverter::class);
+        $this->assertIsInjectable(MarkdownConverterInterface::class);
     }
 
     public function testCompilerIsInjectable()

--- a/tests/View/Compiler/MarkdownCompilerTest.php
+++ b/tests/View/Compiler/MarkdownCompilerTest.php
@@ -17,7 +17,7 @@ use GrahamCampbell\Markdown\View\Compiler\MarkdownCompiler;
 use GrahamCampbell\TestBench\AbstractTestCase;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Application;
-use League\CommonMark\Converter;
+use League\CommonMark\CommonMarkConverter;
 use Mockery;
 
 /**
@@ -51,7 +51,7 @@ class MarkdownCompilerTest extends AbstractTestCase
 
     protected function getCompiler()
     {
-        $markdown = Mockery::mock(Converter::class);
+        $markdown = Mockery::mock(CommonMarkConverter::class);
         $files = Mockery::mock(Filesystem::class);
         $cachePath = __DIR__;
 

--- a/tests/View/Engine/BladeMarkdownEngineTest.php
+++ b/tests/View/Engine/BladeMarkdownEngineTest.php
@@ -16,7 +16,7 @@ namespace GrahamCampbell\Tests\Markdown\View\Engine;
 use GrahamCampbell\Markdown\View\Engine\BladeMarkdownEngine;
 use GrahamCampbell\TestBench\AbstractTestCase;
 use Illuminate\View\Compilers\CompilerInterface;
-use League\CommonMark\Converter;
+use League\CommonMark\CommonMarkConverter;
 use Mockery;
 
 /**
@@ -41,7 +41,7 @@ class BladeMarkdownEngineTest extends AbstractTestCase
     protected function getEngine()
     {
         $compiler = Mockery::mock(CompilerInterface::class);
-        $markdown = Mockery::mock(Converter::class);
+        $markdown = Mockery::mock(CommonMarkConverter::class);
 
         $compiler->shouldReceive('isExpired')->once()
             ->with(__DIR__.'/stubs/test')->andReturn(false);

--- a/tests/View/Engine/PhpMarkdownEngineTest.php
+++ b/tests/View/Engine/PhpMarkdownEngineTest.php
@@ -15,7 +15,7 @@ namespace GrahamCampbell\Tests\Markdown\View\Engine;
 
 use GrahamCampbell\Markdown\View\Engine\PhpMarkdownEngine;
 use GrahamCampbell\TestBench\AbstractTestCase;
-use League\CommonMark\Converter;
+use League\CommonMark\CommonMarkConverter;
 use Mockery;
 
 /**
@@ -39,7 +39,7 @@ class PhpMarkdownEngineTest extends AbstractTestCase
 
     protected function getEngine()
     {
-        $markdown = Mockery::mock(Converter::class);
+        $markdown = Mockery::mock(CommonMarkConverter::class);
 
         return new PhpMarkdownEngine($markdown);
     }


### PR DESCRIPTION
This updates the deprecated code introduced in `league/commonmark:^1.5`.

The composer version of `league/commonmark` has been increased.

I could also target the 2.x release of commonmark if you want.