### PR TITLE
Use commonmark 2.0.0 which is what Laravel 8 already uses

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "illuminate/filesystem": "^6.0 || ^7.0 || ^8.0",
         "illuminate/support": "^6.0 || ^7.0 || ^8.0",
         "illuminate/view": "^6.0 || ^7.0 || ^8.0",
-        "league/commonmark": "^1.5"
+        "league/commonmark": "^2.0.0"
     },
     "require-dev": {
         "graham-campbell/analyzer": "^3.0",


### PR DESCRIPTION
Reference: https://github.com/GrahamCampbell/Laravel-Markdown/issues/158