### PR TITLE
Fix markdown commands formatting to support GitHub copy function

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,13 +18,13 @@ We accept contributions via pull requests on GitHub. Please review these guideli
 First, install the dependencies using [Composer](https://getcomposer.org/):
 
 ```bash
-$ composer install
+composer install
 ```
 
 Then run [PHPUnit](https://phpunit.de/):
 
 ```bash
-$ vendor/bin/phpunit
+vendor/bin/phpunit
 ```
 
 * The tests will be automatically run by [GitHub Actions](https://github.com/features/actions) against pull requests.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This version requires [PHP](https://www.php.net/) 8.1-8.5 and supports [Laravel]
 To get the latest version, simply require the project using [Composer](https://getcomposer.org/):
 
 ```bash
-$ composer require "graham-campbell/markdown:^16.1"
+composer require "graham-campbell/markdown:^16.1"
 ```
 
 Once installed, if you are not using automatic package discovery, then you need to register the `GrahamCampbell\Markdown\MarkdownServiceProvider` service provider in your `config/app.php`.
@@ -50,7 +50,7 @@ Laravel Markdown supports optional configuration.
 To get started, you'll need to publish all vendor assets:
 
 ```bash
-$ php artisan vendor:publish
+php artisan vendor:publish
 ```
 
 This will create a `config/markdown.php` file in your app that you can modify to set your configuration. Also, make sure you check for changes to the original config file in this package between releases.


### PR DESCRIPTION
Removes the $ from the commands in the README.md and CONTRIBUTING.md so it works properly with GitHub’s copy button.

Before, copying the command would include the $ and pasting to terminal required editing.